### PR TITLE
Add MIT license and secure static file serving

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Punthawee Sorseang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/index.html
+++ b/index.html
@@ -501,7 +501,7 @@
                     </div>
                 </div>
                 <div class="contact-form">
-                    <form id="contactForm" action="https://formspree.io/f/your_form_id" method="POST">
+                    <form id="contactForm" action="https://formspree.io/f/mvojnqdb" method="POST">
                         <div class="form-group">
                             <input type="text" id="name" name="name" placeholder="Your Name" required>
                         </div>

--- a/server.js
+++ b/server.js
@@ -14,18 +14,27 @@ const mimeTypes = {
   '.jpeg': 'image/jpeg',
   '.gif': 'image/gif',
   '.svg': 'image/svg+xml',
-  '.ico': 'image/x-icon'
+  '.ico': 'image/x-icon',
+  '.pdf': 'application/pdf'
 };
+
+const baseDir = path.resolve(__dirname);
 
 const server = http.createServer((req, res) => {
   // Decode URL to handle Thai characters properly
-  let filePath = decodeURIComponent('.' + req.url);
-  
-  // Default to index.html
-  if (filePath === './') {
-    filePath = './index.html';
+  let safePath = decodeURIComponent(req.url);
+  if (safePath === '/' || safePath === '') {
+    safePath = '/index.html';
   }
-  
+
+  // Normalize and join the path to prevent directory traversal
+  const filePath = path.resolve(baseDir, '.' + safePath);
+  if (!filePath.startsWith(baseDir)) {
+    res.writeHead(403, { 'Content-Type': 'text/html' });
+    res.end('<h1>403 - Forbidden</h1>', 'utf-8');
+    return;
+  }
+
   const extname = path.extname(filePath).toLowerCase();
   const contentType = mimeTypes[extname] || 'application/octet-stream';
   


### PR DESCRIPTION
## Summary
- add MIT license file for project
- prevent directory traversal and serve PDFs with correct MIME type
- update contact form endpoint to Formspree ID

## Testing
- `npm test` (fails: Missing script "test")
- `node server.js` (server starts and stops)


------
https://chatgpt.com/codex/tasks/task_e_68979bd77088832ea7813903f7d2be7b