### PR TITLE
feat: improve mobile nav and background matrix

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -276,6 +276,7 @@ nav {
     justify-content: space-between;
     align-items: center;
     padding: 15px 0;
+    position: relative;
 }
 
 .logo {
@@ -397,6 +398,45 @@ nav {
     margin: 5px 0;
     transition: var(--transition);
     box-shadow: 0 0 5px var(--primary-color);
+}
+
+@media (max-width: 768px) {
+    .hamburger {
+        display: block;
+    }
+
+    .nav-links {
+        position: absolute;
+        top: 60px;
+        left: 0;
+        right: 0;
+        flex-direction: column;
+        align-items: center;
+        background: var(--bg-color);
+        display: none;
+        padding: 20px 0;
+        border-top: 1px solid var(--primary-color);
+    }
+
+    .nav-links.active {
+        display: flex;
+    }
+
+    .nav-links li {
+        margin: 10px 0;
+    }
+
+    .hamburger.active .line:nth-child(1) {
+        transform: translateY(7px) rotate(45deg);
+    }
+
+    .hamburger.active .line:nth-child(2) {
+        opacity: 0;
+    }
+
+    .hamburger.active .line:nth-child(3) {
+        transform: translateY(-7px) rotate(-45deg);
+    }
 }
 
 /* Hero Section - Galaxy Style */

--- a/js/main.js
+++ b/js/main.js
@@ -370,8 +370,8 @@ function createMatrixRain() {
     matrixCanvas.style.width = '100%';
     matrixCanvas.style.height = '100%';
     matrixCanvas.style.pointerEvents = 'none';
-    matrixCanvas.style.zIndex = '9997';
-    document.body.appendChild(matrixCanvas);
+    matrixCanvas.style.zIndex = '-2';
+    document.body.insertBefore(matrixCanvas, document.body.firstChild);
 
     const ctx = matrixCanvas.getContext('2d');
     matrixCanvas.width = window.innerWidth;


### PR DESCRIPTION
## Summary
- add mobile-friendly navigation with hamburger menu
- move matrix rain effect to background layer

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689840509f34832ebc65bf1af21570e8