### PR TITLE
Tweak mobile typography for smaller screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2901,3 +2901,30 @@ footer::after {
         font-size: 0.9rem;
     }
 }
+
+@media (max-width: 480px) {
+    html {
+        font-size: 14px;
+    }
+
+    .section-title {
+        font-size: 2rem;
+    }
+
+    h1 {
+        font-size: 2rem;
+    }
+
+    h2 {
+        font-size: 1.5rem;
+    }
+
+    h3 {
+        font-size: 1.25rem;
+    }
+
+    .btn {
+        padding: 10px 25px;
+        font-size: 0.8rem;
+    }
+}


### PR DESCRIPTION
## Summary
- reduce base font size and heading styles for devices under 480px width
- shrink button padding and font size for mobile

## Testing
- `npm test` *(fails: Missing script "test"*

------
https://chatgpt.com/codex/tasks/task_e_689841cb4efc832e85408c10a3dcdd9e