### PR TITLE
Clamp mobile timeline and about text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1272,6 +1272,22 @@ nav {
         left: 0;
     }
 
+    .timeline-content > p:not(.timeline-date) {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .about-text p {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
     .cert-grid {
         grid-template-columns: 1fr;
         gap: 20px;


### PR DESCRIPTION
## Summary
- clamp long timeline descriptions to three lines on small screens to reduce clutter
- clamp About Me paragraphs to three lines on small screens to match timeline styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689846ed9d4c832eb57b5c9d76a321e0