### PR TITLE
Add interactive about timeline

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -894,6 +894,40 @@ nav {
     font-size: 1.2rem;
 }
 
+.about-timeline {
+    margin-top: 40px;
+}
+
+.about-toggle {
+    margin-top: 10px;
+    padding: 6px 12px;
+    background: rgba(77, 201, 255, 0.1);
+    color: var(--accent-color);
+    border: 1px solid var(--accent-color);
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 0.9rem;
+    transition: all 0.3s ease;
+    text-shadow: 0 0 5px var(--accent-color);
+}
+
+.about-toggle:hover {
+    background-color: var(--accent-color);
+    color: var(--bg-color);
+    box-shadow: 0 0 15px var(--accent-color);
+    transform: translateY(-3px);
+}
+
+.about-detail {
+    display: none;
+    margin-top: 10px;
+}
+
+.about-detail.open {
+    display: block;
+}
+
 /* Skills Section - Galaxy Style */
 .skills {
     padding: 100px 0;

--- a/index.html
+++ b/index.html
@@ -191,6 +191,58 @@
                     </div>
                 </div>
             </div>
+            <div class="about-timeline">
+                <div class="timeline">
+                    <div class="timeline-item">
+                        <div class="timeline-dot"></div>
+                        <div class="timeline-content">
+                            <h3>2018</h3>
+                            <h4>Graduated B.Sc. Computer Science</h4>
+                            <p class="timeline-date">2018</p>
+                            <button class="about-toggle">Show Details</button>
+                            <div class="about-detail">
+                                <p>Completed my degree at Rajamangala University of Technology Nan with a GPA of 3.19.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-dot"></div>
+                        <div class="timeline-content">
+                            <h3>2019</h3>
+                            <h4>Joined Carabao Tawandang</h4>
+                            <p class="timeline-date">Apr 2019 - Apr 2021</p>
+                            <button class="about-toggle">Show Details</button>
+                            <div class="about-detail">
+                                <p>Worked as a Full Stack Developer building ERP systems and improving cross-platform compatibility.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-dot"></div>
+                        <div class="timeline-content">
+                            <h3>2021</h3>
+                            <h4>Software Developer at CPG</h4>
+                            <p class="timeline-date">Apr 2021 - Aug 2022</p>
+                            <button class="about-toggle">Show Details</button>
+                            <div class="about-detail">
+                                <p>Developed web applications in the Sustainability Unit aligning with corporate governance.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-dot"></div>
+                        <div class="timeline-content">
+                            <h3>2022</h3>
+                            <h4>Senior Backend Developer</h4>
+                            <p class="timeline-date">Aug 2022 - Present</p>
+                            <button class="about-toggle">Show Details</button>
+                            <div class="about-detail">
+                                <p>Lead development of scalable backend services and mentor junior developers at Carabao Tawandang.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -11,6 +11,15 @@ const skillsContent = document.querySelector('.skills-content');
 const timelineContents = document.querySelectorAll('.timeline-content');
 const contactContent = document.querySelector('.contact-content');
 const heroSection = document.querySelector('.hero');
+const aboutToggles = document.querySelectorAll('.about-toggle');
+
+aboutToggles.forEach(btn => {
+    btn.addEventListener('click', () => {
+        const detail = btn.nextElementSibling;
+        detail.classList.toggle('open');
+        btn.textContent = detail.classList.contains('open') ? 'Hide Details' : 'Show Details';
+    });
+});
 
 document.addEventListener('DOMContentLoaded', () => {
     bootSequence();


### PR DESCRIPTION
## Summary
- extend About section with responsive career timeline
- add styles and JavaScript to toggle timeline details

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689849c0cbf0832eae057d385c584cdb