### PR TITLE
style: improve About Me readability on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1294,7 +1294,6 @@ nav {
 @media (max-width: 768px) {
     .about-content {
         flex-direction: column;
-        text-align: center;
         gap: 30px;
     }
 
@@ -1314,6 +1313,12 @@ nav {
 
     .about-text {
         margin-top: 20px;
+        text-align: left;
+    }
+
+    .about-text p {
+        text-align: justify;
+        overflow-wrap: break-word;
     }
 
     .timeline::before {


### PR DESCRIPTION
## Summary
- left-align About section on mobile for cleaner layout
- justify About text and allow word breaks to prevent overflow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689887ce7fb8832e81196f43edda9b39