### PR TITLE
Improve mobile readability in About section

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -881,6 +881,10 @@ nav {
     margin-bottom: 20px;
 }
 
+.about-readmore {
+    display: none;
+}
+
 .about-details {
     margin-top: 30px;
 }
@@ -1316,9 +1320,36 @@ nav {
         text-align: left;
     }
 
-    .about-text p {
+    .about-description {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    .about-description p {
         text-align: justify;
         overflow-wrap: break-word;
+    }
+
+    .about-text.expanded .about-description {
+        -webkit-line-clamp: unset;
+        overflow: visible;
+    }
+
+    .about-readmore {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 6px 12px;
+        background: rgba(77, 201, 255, 0.1);
+        color: var(--accent-color);
+        border: 1px solid var(--accent-color);
+        border-radius: 5px;
+        cursor: pointer;
+        font-family: 'Share Tech Mono', monospace;
+        font-size: 0.9rem;
+        transition: all 0.3s ease;
+        text-shadow: 0 0 5px var(--accent-color);
     }
 
     .timeline::before {

--- a/index.html
+++ b/index.html
@@ -176,9 +176,12 @@
                     <img src="assets/images/project-placeholder.jpg" alt="Punthawee Sorseang" onerror="this.onerror=null;this.src='assets/images/portfolio-default.png';">
                 </div>
                 <div class="about-text">
-                    <p>Welcome to my portfolio! I'm currently a Senior Backend Developer at Carabao Tawandang, focusing on developing backend applications that are essential to the organization's core operations. My role involves creating efficient and scalable solutions to meet the company's growing needs.</p>
-                    <p>My approach to work combines analytical thinking with creative problem-solving. I thrive in collaborative environments and am dedicated to delivering high-quality results through microservices architectures, agile workflows, and continuous improvement practices.</p>
-                    <p>With expertise spanning backend and frontend development, I continuously explore new technologies to build innovative solutions and mentor junior developers to foster professional growth.</p>
+                    <div class="about-description">
+                        <p>Welcome to my portfolio! I'm currently a Senior Backend Developer at Carabao Tawandang, focusing on developing backend applications that are essential to the organization's core operations. My role involves creating efficient and scalable solutions to meet the company's growing needs.</p>
+                        <p>My approach to work combines analytical thinking with creative problem-solving. I thrive in collaborative environments and am dedicated to delivering high-quality results through microservices architectures, agile workflows, and continuous improvement practices.</p>
+                        <p>With expertise spanning backend and frontend development, I continuously explore new technologies to build innovative solutions and mentor junior developers to foster professional growth.</p>
+                    </div>
+                    <button class="about-readmore" aria-expanded="false">Read More</button>
                     <div class="about-details">
                         <div class="detail-item">
                             <i class="fas fa-graduation-cap"></i>

--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,7 @@ const timelineContents = document.querySelectorAll('.timeline-content');
 const contactContent = document.querySelector('.contact-content');
 const heroSection = document.querySelector('.hero');
 const aboutToggles = document.querySelectorAll('.about-toggle');
+const aboutReadMore = document.querySelector('.about-readmore');
 
 aboutToggles.forEach(btn => {
     btn.addEventListener('click', () => {
@@ -22,6 +23,15 @@ aboutToggles.forEach(btn => {
         btn.setAttribute('aria-expanded', isOpen);
     });
 });
+
+if (aboutReadMore) {
+    aboutReadMore.addEventListener('click', () => {
+        const aboutText = document.querySelector('.about-text');
+        const expanded = aboutText.classList.toggle('expanded');
+        aboutReadMore.textContent = expanded ? 'Show Less' : 'Read More';
+        aboutReadMore.setAttribute('aria-expanded', expanded);
+    });
+}
 
 document.addEventListener('DOMContentLoaded', () => {
     bootSequence();


### PR DESCRIPTION
## Summary
- Clamp long About text on small screens and add a Read More toggle
- Style mobile About section for cleaner presentation
- Support Read More interactions with JavaScript

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689889e7b038832e901b19cd7c590002