### PR TITLE
style: enhance project cards and tags

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -9,14 +9,17 @@ body{background:var(--bg);color:var(--fg);font:16px/1.6 system-ui,Segoe UI,Robot
 .flex-grow{flex:1}
 
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px}
-.card{display:block;padding:16px;border:1px solid rgba(127,127,127,.18);border-radius:12px;background:var(--card);text-decoration:none;color:inherit;transition:transform .15s ease, border-color .15s}
-.card:hover{transform:translateY(-2px);border-color:var(--brand)}
+.card{display:block;padding:16px;border:1px solid rgba(127,127,127,.18);border-radius:12px;background:var(--card);text-decoration:none;color:inherit;transition:transform .15s ease,border-color .15s,box-shadow .15s}
+.card:hover{transform:translateY(-4px);border-color:var(--brand);box-shadow:0 4px 8px rgba(0,0,0,.08)}
 .card h3{margin:0 0 .25rem}
 .card p{margin:.25rem 0 .5rem;color:var(--muted);min-height:2.2em}
-.card small{color:var(--muted)}
+.card small{display:flex;align-items:center;gap:8px;color:var(--muted);margin-top:.25rem}
+.card small i{color:var(--brand)}
+.tags{margin-top:8px;display:flex;flex-wrap:wrap;gap:6px}
 
 .chips{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 18px}
-.chip{padding:6px 10px;border-radius:999px;background:var(--chip);cursor:pointer;border:1px solid transparent;user-select:none}
+.chip{padding:6px 10px;border-radius:999px;background:var(--chip);cursor:pointer;border:1px solid transparent;user-select:none;transition:background-color .2s,color .2s}
+.chip:hover{background:var(--brand);color:var(--bg)}
 .chip.active{outline:2px solid var(--brand);background:transparent}
 
 .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center;z-index:100}

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -163,8 +163,11 @@ function repoCard(r){
   <a class="card" href="${r.html_url}" target="_blank" rel="noopener">
     <h3>${r.name}</h3>
     <p>${r.description||''}</p>
-    <small>★ ${r.stargazers_count} • ${r.language||'—'}</small>
-    <div style="margin-top:8px">${tagHtml}</div>
+    <small>
+      <i class="fa-solid fa-star"></i> ${r.stargazers_count}
+      <i class="fa-solid fa-code"></i> ${r.language||'—'}
+    </small>
+    <div class="tags">${tagHtml}</div>
     ${csHtml}
   </a>`;
 }


### PR DESCRIPTION
## Summary
- Improve project card visuals with hover shadow, icon meta, and tag container
- Add interactive styling for tag chips and card icons

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a24bef69c832e86b9e043fa659140