### PR TITLE
feat: add dark mode, i18n, and contact utilities

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -1,0 +1,15 @@
+{
+  "nav.home": "Home",
+  "nav.about": "About",
+  "nav.skills": "Skills",
+  "nav.experience": "Experience",
+  "nav.projects": "Projects",
+  "nav.certifications": "Certifications",
+  "nav.education": "Education",
+  "nav.contact": "Contact",
+  "contact.title": "Get In Touch",
+  "contact.email": "Email",
+  "contact.phone": "Phone",
+  "contact.vcard": "Download vCard",
+  "contact.qr": "Download QR"
+}

--- a/assets/i18n/th.json
+++ b/assets/i18n/th.json
@@ -1,0 +1,15 @@
+{
+  "nav.home": "หน้าแรก",
+  "nav.about": "เกี่ยวกับ",
+  "nav.skills": "ทักษะ",
+  "nav.experience": "ประสบการณ์",
+  "nav.projects": "โครงการ",
+  "nav.certifications": "ใบรับรอง",
+  "nav.education": "การศึกษา",
+  "nav.contact": "ติดต่อ",
+  "contact.title": "ติดต่อเรา",
+  "contact.email": "อีเมล",
+  "contact.phone": "โทรศัพท์",
+  "contact.vcard": "ดาวน์โหลด vCard",
+  "contact.qr": "ดาวน์โหลด QR"
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -22,6 +22,13 @@
     --nebula-color-3: rgba(77, 201, 255, 0.4); /* Blue */
 }
 
+body.light-mode {
+    --text-color: #0a0a20;
+    --bg-color: #f8f9fa;
+    --border-color: #dddddd;
+    --shadow-color: rgba(0, 0, 0, 0.1);
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -40,6 +47,10 @@ body {
     transition: var(--transition);
     position: relative;
     overflow-x: hidden;
+}
+
+body.theme-transition {
+    transition: background-color 0.5s ease, color 0.5s ease;
 }
 
 h1,
@@ -383,7 +394,26 @@ nav {
 
 /* --- HIDE THEME TOGGLE --- */
 .theme-toggle {
-    display: none;
+    display: block;
+    cursor: pointer;
+    margin-right: 1rem;
+}
+
+.lang-toggle {
+    display: flex;
+    gap: 0.25rem;
+    margin-right: 1rem;
+}
+
+.lang-toggle button {
+    background: none;
+    border: none;
+    color: var(--text-color);
+    cursor: pointer;
+}
+
+.lang-toggle button.active {
+    color: var(--secondary-color);
 }
 
 .hamburger {
@@ -1710,6 +1740,38 @@ nav {
 
 .contact-item h3 {
     margin-bottom: 5px;
+}
+
+.copy-btn {
+    background: none;
+    border: none;
+    color: var(--accent-color);
+    margin-left: 5px;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.contact-actions {
+    margin-top: 10px;
+    display: flex;
+    gap: 10px;
+}
+
+.contact-action-btn {
+    background-color: var(--primary-color);
+    color: var(--text-color);
+    border: none;
+    padding: 8px 12px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: var(--transition);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.contact-action-btn:hover {
+    background-color: var(--secondary-color);
 }
 
 .contact-form {

--- a/index.html
+++ b/index.html
@@ -125,15 +125,20 @@
             <nav>
                 <div class="logo">Punthawee Sorseang<span class="logo-blink">_</span></div>
                 <ul class="nav-links">
-                    <li><a href="#home">Home</a></li>
-                    <li><a href="#about">About</a></li>
-                    <li><a href="#skills">Skills</a></li>
-                    <li><a href="#experience">Experience</a></li>
-                    <li><a href="#projects">Projects</a></li>
-                    <li><a href="#certifications">Certifications</a></li>
-                    <li><a href="#education">Education</a></li>
-                    <li><a href="#contact">Contact</a></li>
+                    <li><a href="#home" data-i18n="nav.home">Home</a></li>
+                    <li><a href="#about" data-i18n="nav.about">About</a></li>
+                    <li><a href="#skills" data-i18n="nav.skills">Skills</a></li>
+                    <li><a href="#experience" data-i18n="nav.experience">Experience</a></li>
+                    <li><a href="#projects" data-i18n="nav.projects">Projects</a></li>
+                    <li><a href="#certifications" data-i18n="nav.certifications">Certifications</a></li>
+                    <li><a href="#education" data-i18n="nav.education">Education</a></li>
+                    <li><a href="#contact" data-i18n="nav.contact">Contact</a></li>
                 </ul>
+
+                <div class="lang-toggle">
+                    <button data-lang="en">EN</button>
+                    <button data-lang="th">TH</button>
+                </div>
 
                 <div class="theme-toggle">
                     <i class="fas fa-moon"></i>
@@ -534,22 +539,32 @@
 
     <section id="contact" class="contact">
         <div class="container">
-            <h2 class="section-title">Get In Touch</h2>
+            <h2 class="section-title" data-i18n="contact.title">Get In Touch</h2>
             <div class="contact-content">
                 <div class="contact-info">
                     <div class="contact-item">
                         <i class="fas fa-envelope"></i>
                         <div>
-                            <h3>Email</h3>
-                            <p><a href="mailto:punthaweeso@gmail.com">punthaweeso@gmail.com</a></p>
+                            <h3 data-i18n="contact.email">Email</h3>
+                            <p>
+                                <a href="mailto:punthaweeso@gmail.com" id="contactEmail">punthaweeso@gmail.com</a>
+                                <button class="copy-btn" data-copy-target="contactEmail" title="Copy"><i class="fas fa-copy"></i></button>
+                            </p>
                         </div>
                     </div>
                      <div class="contact-item">
                         <i class="fas fa-phone"></i>
                         <div>
-                            <h3>Phone</h3>
-                            <p>+66-90-972-4819</p>
+                            <h3 data-i18n="contact.phone">Phone</h3>
+                            <p>
+                                <span id="contactPhone">+66-90-972-4819</span>
+                                <button class="copy-btn" data-copy-target="contactPhone" title="Copy"><i class="fas fa-copy"></i></button>
+                            </p>
                         </div>
+                    </div>
+                    <div class="contact-actions">
+                        <button id="downloadVCard" class="contact-action-btn"><i class="fas fa-address-card"></i> <span data-i18n="contact.vcard">Download vCard</span></button>
+                        <button id="downloadQR" class="contact-action-btn"><i class="fas fa-qrcode"></i> <span data-i18n="contact.qr">Download QR</span></button>
                     </div>
                     <div class="social-icons">
                         <a href="https://www.linkedin.com/in/punthawee-sorseang-0775ba1b3" target="_blank"><i class="fab fa-linkedin"></i></a>
@@ -680,22 +695,32 @@
             const body = document.body;
 
             const applyTheme = (theme) => {
+                body.classList.add('theme-transition');
                 if (theme === 'dark') {
                     body.classList.add('dark-mode');
+                    body.classList.remove('light-mode');
                     themeIcon.classList.remove('fa-sun');
                     themeIcon.classList.add('fa-moon');
                 } else {
                     body.classList.remove('dark-mode');
+                    body.classList.add('light-mode');
                     themeIcon.classList.remove('fa-moon');
                     themeIcon.classList.add('fa-sun');
                 }
+                setTimeout(() => body.classList.remove('theme-transition'), 500);
             };
 
-            // On page load, check for saved theme. Default to dark if none found.
-            const savedTheme = localStorage.getItem('theme') || 'dark';
-            applyTheme(savedTheme);
+            const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+            const savedTheme = localStorage.getItem('theme');
+            const initialTheme = savedTheme || (systemPrefersDark.matches ? 'dark' : 'light');
+            applyTheme(initialTheme);
 
-            // Add click listener for the toggle button
+            systemPrefersDark.addEventListener('change', e => {
+                if (!localStorage.getItem('theme')) {
+                    applyTheme(e.matches ? 'dark' : 'light');
+                }
+            });
+
             themeToggle.addEventListener('click', () => {
                 const isDarkMode = body.classList.contains('dark-mode');
                 const newTheme = isDarkMode ? 'light' : 'dark';

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,10 @@ const contactContent = document.querySelector('.contact-content');
 const heroSection = document.querySelector('.hero');
 const aboutToggles = document.querySelectorAll('.about-toggle');
 const aboutReadMore = document.querySelector('.about-readmore');
+const copyBtns = document.querySelectorAll('.copy-btn');
+const downloadVCardBtn = document.getElementById('downloadVCard');
+const downloadQRBtn = document.getElementById('downloadQR');
+const langButtons = document.querySelectorAll('.lang-toggle button');
 
 aboutToggles.forEach(btn => {
     btn.addEventListener('click', () => {
@@ -786,7 +790,8 @@ async function loadImageContent() {
 
 function loadPDFContent() {
     certModalLoading.style.display = 'none';
-    certModalPDF.src = currentCertData.pdf;
+    const viewer = 'https://mozilla.github.io/pdf.js/web/viewer.html?file=' + encodeURIComponent(currentCertData.pdf);
+    certModalPDF.src = viewer;
 }
 
 function showErrorMessage(message) {
@@ -831,4 +836,70 @@ document.addEventListener('keydown', e => {
     if (e.key === 'Escape' && certificateModal.style.display === 'block') {
         closeCertificateModal();
     }
+});
+
+// Copy contact info
+copyBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+        const target = document.getElementById(btn.dataset.copyTarget);
+        if (target) {
+            navigator.clipboard.writeText(target.textContent.trim());
+        }
+    });
+});
+
+// vCard download
+if (downloadVCardBtn) {
+    downloadVCardBtn.addEventListener('click', () => {
+        const vcard = `BEGIN:VCARD\nVERSION:3.0\nFN:Punthawee Sorseang\nEMAIL:punthaweeso@gmail.com\nTEL:+66909724819\nEND:VCARD`;
+        const blob = new Blob([vcard], { type: 'text/vcard' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'punthawee-sorseang.vcf';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    });
+}
+
+// QR download
+if (downloadQRBtn) {
+    downloadQRBtn.addEventListener('click', () => {
+        const data = encodeURIComponent('MECARD:N:Punthawee Sorseang;TEL:+66909724819;EMAIL:punthaweeso@gmail.com;;');
+        const url = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${data}`;
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'contact-qr.png';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    });
+}
+
+// Language switcher
+function setLanguage(lang) {
+    fetch(`assets/i18n/${lang}.json`)
+        .then(res => res.json())
+        .then(data => {
+            document.querySelectorAll('[data-i18n]').forEach(el => {
+                const key = el.getAttribute('data-i18n');
+                if (data[key]) {
+                    el.textContent = data[key];
+                }
+            });
+            localStorage.setItem('lang', lang);
+            document.documentElement.setAttribute('lang', lang);
+            langButtons.forEach(b => b.classList.toggle('active', b.dataset.lang === lang));
+        });
+}
+
+const savedLang = localStorage.getItem('lang') || (navigator.language.startsWith('th') ? 'th' : 'en');
+setLanguage(savedLang);
+
+langButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+        setLanguage(btn.dataset.lang);
+    });
 });


### PR DESCRIPTION
## Summary
- support system-aware dark mode with animated theme switching
- embed PDF.js viewer for stable certificate modal
- add copy, vCard, and QR features for contact info
- introduce English/Thai i18n with JSON resources

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b3cecc5fc832eb2eace8534b9e4bb