### PR TITLE
Default to dark theme and English language

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1697,6 +1697,10 @@ nav {
     overflow: hidden;
 }
 
+.contact .section-title {
+    font-size: clamp(1.8rem, 5vw, 2.5rem);
+}
+
 .contact::before {
     content: '';
     position: absolute;

--- a/index.html
+++ b/index.html
@@ -712,7 +712,7 @@
 
             const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)');
             const savedTheme = localStorage.getItem('theme');
-            const initialTheme = savedTheme || (systemPrefersDark.matches ? 'dark' : 'light');
+            const initialTheme = savedTheme || 'dark';
             applyTheme(initialTheme);
 
             systemPrefersDark.addEventListener('change', e => {

--- a/js/main.js
+++ b/js/main.js
@@ -895,7 +895,7 @@ function setLanguage(lang) {
         });
 }
 
-const savedLang = localStorage.getItem('lang') || (navigator.language.startsWith('th') ? 'th' : 'en');
+const savedLang = localStorage.getItem('lang') || 'en';
 setLanguage(savedLang);
 
 langButtons.forEach(btn => {


### PR DESCRIPTION
## Summary
- Default theme set to dark unless user saves a preference
- Default language forced to English on initial load
- Adjusted "Get In Touch" heading to scale responsively

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b414dbddc832eb1c555fe01c98512